### PR TITLE
Expose NVM to sh interactive shell via ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,11 @@ ARG bashEnv=/etc/bash.bashrc
 # First move the template file over
 RUN mkdir ${tempDir}
 COPY env.bashrc ${tempDir}/env.bashrc
-COPY env.bashrc /usr/local/env.sh
+# COPY env.bashrc /usr/local/env.sh
 
 # Next, make the file available to all to read and source
-RUN chmod +r /usr/local/env.sh
-ENV ENV=/usr/local/env.sh
+# RUN chmod +r /usr/local/env.sh
+ENV ENV=${bashEnv}
 
 # Create a shell file that applies the configuration for sessions. (anything not bash really)
 RUN touch ${sshEnv} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ USER jenkins
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 USER root
 
+# Get rid of dash and use bash instead
+RUN echo "dash dash/sh boolean false" | debconf-set-selections
+RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
 ARG tempDir=/tmp/jenkins-npm-agent
 ARG sshEnv=/etc/profile.d/npm_setup.sh
 ARG bashEnv=/etc/bash.bashrc
@@ -47,6 +51,11 @@ ARG bashEnv=/etc/bash.bashrc
 # First move the template file over
 RUN mkdir ${tempDir}
 COPY env.bashrc ${tempDir}/env.bashrc
+COPY env.bashrc /usr/local/env.sh
+
+# Next, make the file available to all to read and source
+RUN chmod +r /usr/local/env.sh
+ENV ENV=/usr/local/env.sh
 
 # Create a shell file that applies the configuration for sessions. (anything not bash really)
 RUN touch ${sshEnv} \


### PR DESCRIPTION
sh doesn't source from .profile when run interactively (non-login). It also uses dash's implementation of sh instead of bash.

To resolve those issues, this PR uses bash's implementation of sh, and sets the ENV environment variable, which will source the file it points to in a sh interactive shell. In this case, this makes nvm, npm, and node available.